### PR TITLE
Apply chain policy from chain attributes

### DIFF
--- a/cmd/concurrent/concurrent.go
+++ b/cmd/concurrent/concurrent.go
@@ -21,6 +21,7 @@ import (
 
 var (
 	cpuprofile = flag.String("cpuprofile", "", "write cpu profile to file")
+	accept     = nftableslib.ChainPolicyAccept
 )
 
 var tests = []setenv.NFTablesTest{
@@ -34,7 +35,7 @@ var tests = []setenv.NFTablesTest{
 					Type:     nftables.ChainTypeFilter,
 					Priority: 0,
 					Hook:     nftables.ChainHookInput,
-					Policy:   nftableslib.ChainPolicyAccept,
+					Policy:   &accept,
 				},
 				Rules: []nftableslib.Rule{
 					{
@@ -256,7 +257,7 @@ var tests = []setenv.NFTablesTest{
 					Type:     nftables.ChainTypeFilter,
 					Priority: 0,
 					Hook:     nftables.ChainHookInput,
-					Policy:   nftableslib.ChainPolicyAccept,
+					Policy:   &accept,
 				},
 				Rules: []nftableslib.Rule{
 					{

--- a/cmd/e2e/e2e.go
+++ b/cmd/e2e/e2e.go
@@ -14,6 +14,8 @@ import (
 	"github.com/sbezverk/nftableslib/pkg/e2e/validations"
 )
 
+var accept = nftableslib.ChainPolicyAccept
+
 func init() {
 	runtime.LockOSThread()
 }
@@ -30,7 +32,7 @@ func main() {
 						Type:     nftables.ChainTypeFilter,
 						Priority: 0,
 						Hook:     nftables.ChainHookInput,
-						Policy:   nftableslib.ChainPolicyAccept,
+						Policy:   &accept,
 					},
 					Rules: []nftableslib.Rule{
 						{
@@ -275,7 +277,7 @@ func main() {
 						Type:     nftables.ChainTypeFilter,
 						Priority: 0,
 						Hook:     nftables.ChainHookInput,
-						Policy:   nftableslib.ChainPolicyAccept,
+						Policy:   &accept,
 					},
 					Rules: []nftableslib.Rule{
 						{

--- a/cmd/e2e/testsync.go
+++ b/cmd/e2e/testsync.go
@@ -54,7 +54,7 @@ func testSync() error {
 					Type:     nftables.ChainTypeFilter,
 					Priority: 0,
 					Hook:     nftables.ChainHookInput,
-					Policy:   nftableslib.ChainPolicyAccept,
+					Policy:   &accept,
 				},
 				Rules: []nftableslib.Rule{
 					{


### PR DESCRIPTION
Commit https://github.com/sbezverk/nftableslib/commit/b58bb3e2dd5865312edd5e04c8489e922f7b3400 addresses changes in https://github.com/google/nftables/pull/65 by always setting default chain policy to ChainPolicyAccept. This commit applies value from chain attributes but it breaks compatibility with previous version. The code that explicitly sets the policy field in chain attributes won't be compiled.